### PR TITLE
fixed typo in join datasets left parameter default value

### DIFF
--- a/src/dataset_tools/core.clj
+++ b/src/dataset_tools/core.clj
@@ -106,7 +106,7 @@
   "Join two datasets (dsx, dsy) using the key functions fx and fy.
    If :left is set to true then the join will be a left join, otherwise
    the join will be an inner join."
-  [fx fy dsx dsy & {:keys [left] :or {:left false}}]
+  [fx fy dsx dsy & {:keys [left] :or {left false}}]
   (let [m (->> dsy
                from-dataset
                (group-by fy))


### PR DESCRIPTION
Cannot run task `lein uberjar` with clojure 1.9.
Corresponding error is
```
Exception in thread "main" clojure.lang.ExceptionInfo: Call to clojure.core/defn did not conform to spec:
In: [2 5 :or :left 0] val: :left fails spec: :clojure.core.specs.alpha/or at: [:args :bs :arity-1 :args :varargs :form :map :or 0] predicate: simple-symbol?
In: [2 5] val: {:keys [left], :or {:left false}} fails spec: :clojure.core.specs.alpha/local-name at: [:args :bs :arity-1 :args :varargs :form :sym] predicate: simple-symbol?
In: [2 5] val: {:keys [left], :or {:left false}} fails spec: :clojure.core.specs.alpha/seq-binding-form at: [:args :bs :arity-1 :args :varargs :form :seq] predicate: vector?
In: [2 0] val: fx fails spec: :clojure.core.specs.alpha/arg-list at: [:args :bs :arity-n :bodies :args] predicate: vector?
 #:clojure.spec.alpha{:problems ({:path [:args :bs :arity-1 :args :varargs :form :sym], :pred clojure.core/simple-symbol?, :val {:keys [left], :or {:left false}}, :via [:clojure.core.specs.alpha/defn-args :clojure.core.specs.alpha/args+body :clojure.core.specs.alpha/arg-list :clojure.core.specs.alpha/arg-list :clojure.core.specs.alpha/binding-form :clojure.core.specs.alpha/binding-form :clojure.core.specs.alpha/local-name], :in [2 5]} {:path [:args :bs :arity-1 :args :varargs :form :seq], :pred clojure.core/vector?, :val {:keys [left], :or {:left false}}, :via [:clojure.core.specs.alpha/defn-args :clojure.core.specs.alpha/args+body :clojure.core.specs.alpha/arg-list :clojure.core.specs.alpha/arg-list :clojure.core.specs.alpha/binding-form :clojure.core.specs.alpha/binding-form :clojure.core.specs.alpha/seq-binding-form], :in [2 5]} {:path [:args :bs :arity-1 :args :varargs :form :map :or 0], :pred clojure.core/simple-symbol?, :val :left, :via [:clojure.core.specs.alpha/defn-args :clojure.core.specs.alpha/args+body :clojure.core.specs.alpha/arg-list :clojure.core.specs.alpha/arg-list :clojure.core.specs.alpha/binding-form :clojure.core.specs.alpha/binding-form :clojure.core.specs.alpha/map-binding-form :clojure.core.specs.alpha/map-special-binding :clojure.core.specs.alpha/or], :in [2 5 :or :left 0]} {:path [:args :bs :arity-n :bodies :args], :pred clojure.core/vector?, :val fx, :via [:clojure.core.specs.alpha/defn-args :clojure.core.specs.alpha/args+body :clojure.core.specs.alpha/args+body :clojure.core.specs.alpha/args+body :clojure.core.specs.alpha/arg-list :clojure.core.specs.alpha/arg-list], :in [2 0]}), :spec #object[clojure.spec.alpha$regex_spec_impl$reify__2436 0x4668c46 "clojure.spec.alpha$regex_spec_impl$reify__2436@4668c46"], :value (join "Join two datasets (dsx, dsy) using the key functions fx and fy.\n   If :left is set to true then the join will be a left join, otherwise\n   the join will be an inner join." [fx fy dsx dsy & {:keys [left], :or {:left false}}] (let [m (->> dsy from-dataset (group-by fy)) xcols (md/column-names dsx) ycols (md/column-names dsy) ucols (distinct (concat xcols ycols)) dcols (diff ycols xcols)] (->> dsx from-dataset (map (fn [x] (let [g (map (fn* [p1__49528#] (merge x (select-keys p1__49528# dcols))) (get m (fx x)))] (if (and left (empty? g)) (reduce (fn* [p1__49529# p2__49530#] (update p1__49529# p2__49530# (constantly nil))) x dcols) g)))) flatten (to-dataset ucols)))), :args (join "Join two datasets (dsx, dsy) using the key functions fx and fy.\n   If :left is set to true then the join will be a left join, otherwise\n   the join will be an inner join." [fx fy dsx dsy & {:keys [left], :or {:left false}}] (let [m (->> dsy from-dataset (group-by fy)) xcols (md/column-names dsx) ycols (md/column-names dsy) ucols (distinct (concat xcols ycols)) dcols (diff ycols xcols)] (->> dsx from-dataset (map (fn [x] (let [g (map (fn* [p1__49528#] (merge x (select-keys p1__49528# dcols))) (get m (fx x)))] (if (and left (empty? g)) (reduce (fn* [p1__49529# p2__49530#] (update p1__49529# p2__49530# (constantly nil))) x dcols) g)))) flatten (to-dataset ucols))))}, compiling:(dataset_tools/core.clj:105:1)
```

Versions:
`[dataset-tools "0.1.12"]`
`[org.clojure/clojure "1.9.0"]`
```
➜ lein version
Leiningen 2.8.1 on Java 1.8.0_181 Java HotSpot(TM) 64-Bit Server VM
```


